### PR TITLE
Remove .toml extension as it is not needed, and results in double ext…

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	ConfigFile            string // Path to the config file, if any
-	DefaultConfigFilename = "cloudflare-ddns.toml"
+	DefaultConfigFilename = "cloudflare-ddns"
 
 	Config = StringOption{
 		Name:        "config",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattolenik/cloudflare-ddns-client
 
-go 1.17
+go 1.20
 
 require (
 	github.com/cloudflare/cloudflare-go v0.30.0


### PR DESCRIPTION
Resolves the issue of not finding the .toml file without using the extension of .toml.toml.